### PR TITLE
nanorc: Fix documentation flaw inherited from nano 2.3.1's default nanorc

### DIFF
--- a/.nanorc
+++ b/.nanorc
@@ -1,6 +1,6 @@
 ## This is a system-wide configuration file for the nano editor.
 ##
-## Each user can save his own configuration to ~/.nanorc
+## Each user can save their own configuration to ~/.nanorc
 ##
 ## See the nanorc(5) man page for details.
 


### PR DESCRIPTION
This version of nano came with a default configuration which rendered use of the program by anyone who wasn't male undefined behaviour. This patch fixes this bug with extreme lack of prejudice.

...okay, this is far from the most important change, but undefined behaviour is undefined behaviour. It's a slippery slope: first, you're writing inaccurate/underspecific documentation, the next, you're writing to a null pointer from 75 threads at once...