### PR TITLE
Fix sh not recognizing bash test characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Nano with LISP syntax highlighting that can run on the TAMU Linux Servers
 ## Install
 Automatic install via a script on the TAMU Linux server:
 ```
-curl https://raw.githubusercontent.com/pulchroxloom/.nano/master/installer.sh | sh
+curl https://raw.githubusercontent.com/pulchroxloom/.nano/master/installer.sh | bash
 ```
 or
 ```
-wget https://raw.githubusercontent.com/pulchroxloom/.nano/master/installer.sh -O- | sh
+wget https://raw.githubusercontent.com/pulchroxloom/.nano/master/installer.sh -O- | bash
 ```
 The script will download the configs that you need to make `nano` a little more friendly and the syntax definitions for LISP (Scheme is a type of LISP).
 


### PR DESCRIPTION
In `dash`, the default Ubuntu shell, `[[` is not a valid way to open a test in an if. The fix is to directly invoke `bash` instead of relying on the `sh` link to resolve to `bash`.